### PR TITLE
Proper debate closure

### DIFF
--- a/src/debate/debate.js
+++ b/src/debate/debate.js
@@ -110,6 +110,23 @@ export class Debate {
         this.userNamespace.use(new ClientBlacklistMiddleware().middlewareFunction);
     }
 
+    close(io) {
+        logger.info(`Closing debate with id (${this.debateID})`);
+
+        logger.debug(`Disconnecting clients...`);
+        for (let [uuid, client] of this.clients) {
+            client.socket.disconnect(true);
+        }
+
+        logger.debug('Removing listeners...');
+        this.userNamespace.removeAllListeners();
+
+        logger.debug('Deleting namespace reference...');
+        delete io.nsps[`${SocketConfig.DEBATE_NAMESPACE_PREFIX}${this.debateID}`];
+
+        logger.info('Debate has been closed.');
+    }
+
     /**
      * Starts handling for client events.
      */

--- a/src/debatemanager.js
+++ b/src/debatemanager.js
@@ -21,7 +21,7 @@ export class DebateManager {
     async start() {
         this.startWebServer();
         this.startSocketServer();
-        this.startAdminNamespace();
+        this.startPrivilegedNamespace();
 
         await dbManager.start();
         await this.initializeDebates();
@@ -79,7 +79,7 @@ export class DebateManager {
     /**
      * Creates a new Privilegednamespace and registers our middleware.
      */
-    startAdminNamespace() {
+    startPrivilegedNamespace() {
         this.nspAdmin = new PrivilegedNamespace(this.io);
         const adminMiddleware = new LoginMiddleware();
 

--- a/src/namespace/privilegednamespace.js
+++ b/src/namespace/privilegednamespace.js
@@ -159,6 +159,7 @@ export class PrivilegedNamespace extends CustomNamespace {
             logger.debug(`No active debate with the id ${aIdDiscussion} was found`);
             return;
         }
+        debate.close(this.io);
         // Delete debate from active debates
         this.activeDebates.delete(aIdDiscussion);
         // Save in the database that the discussion is closed


### PR DESCRIPTION
Close the debate properly by freeing memory and unregistering events.